### PR TITLE
fix: :bug: Fix delete event trigger and move algolia client position.

### DIFF
--- a/apollo/src/PubSubHandlers.js
+++ b/apollo/src/PubSubHandlers.js
@@ -11,9 +11,10 @@ const subscription = pubSubClient.subscription(subscriptionName);
  *
  * @param {import('firebase-admin').firestore.Firestore} firestore
  * @param {import('events').EventEmitter} eventEmitter
+ * @param {import('algoliasearch').SearchIndex} algoliaIndexClient
  * @returns
  */
-const PubSubHandlers = (firestore, eventEmitter) => ({
+const PubSubHandlers = (firestore, eventEmitter, algoliaIndexClient) => ({
   archivedThreshold_change: onMessage =>
     firestore
       .collection('setting')
@@ -64,9 +65,10 @@ const PubSubHandlers = (firestore, eventEmitter) => ({
         },
       });
 
-      // trigger algolia_object_delete event
-      // event emitted location: constructor in [CAMPUS-backend dir]/apollo/src/datasources/TagDataSource.js
-      eventEmitter.emit('algolia_object_delete', idWithResultData.id);
+      const { id } = idWithResultData;
+      // algolia_object_delete
+      // It's async function, but no need to await in this situation
+      algoliaIndexClient.deleteObject(id);
 
       // "Ack" (acknowledge receipt of) the message
       message.ack();

--- a/functions/functionTriggers/deleteTagTrigger.js
+++ b/functions/functionTriggers/deleteTagTrigger.js
@@ -38,6 +38,7 @@ async function deleteTagTrigger(admin, snap) {
     logger.log(`publish ${tagId} delete event, message id: ${messageId}`);
   } catch (error) {
     logger.log(`publish ${tagId} delete event failed on topic ${topicName}`);
+    logger.log(error);
   }
 
   // Decrement userAddTagNumber


### PR DESCRIPTION
* Print error of publishing event from firestore delete event function
  trigger.
* Move algolia client to `apolloServerGenerator`, so that client can
  directly pass to TagDataSource and PubSubHandler.
* Print algolia index objects update results.