### PR TITLE
fix: :bug: Rewrite some resolvers to process data from Pub/Sub

### DIFF
--- a/functions/functionTriggers/deleteTagTrigger.js
+++ b/functions/functionTriggers/deleteTagTrigger.js
@@ -29,10 +29,19 @@ async function deleteTagTrigger(admin, snap) {
   // publish delete event by Pub/Sub
   // https://cloud.google.com/pubsub/docs/quickstart-client-libraries#publish_messages
   try {
+    // these fields are firestore object, need to process before encode to JSON string
+    const { createTime, lastUpdateTime, coordinates } = snap.data();
+    const { latitude, longitude } = coordinates;
     const dataBuffer = Buffer.from(
       JSON.stringify({
         changeType: "deleted",
-        tagContent: { id: tagId, ...snap.data() },
+        tagContent: {
+          id: tagId,
+          createTime: createTime.toDate().toISOString(),
+          lastUpdateTime: lastUpdateTime.toDate().toISOString(),
+          coordinates: { latitude, longitude },
+          ...snap.data(),
+        },
       })
     );
     const messageId = await pubSubClient.topic(topicName).publish(dataBuffer);


### PR DESCRIPTION
* Since some fields in the tag would loss information when transform to
  json string and send by Pub/Sub, we transform the object in the
  `deleteTagTrigger.` and send them using Pub/Sub. The new rewriting
  resolver can process these fields.