### PR TITLE
build: :hammer: Add pubsub emulator to docker-compose for testing

### DIFF
--- a/.github/workflows/apollo_graphql_deploy_to_run.yml
+++ b/.github/workflows/apollo_graphql_deploy_to_run.yml
@@ -50,4 +50,7 @@ jobs:
         service: ${{ env.SERVICE }}
         image: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{  github.sha }}
         region: ${{ env.REGION }}
+        # https://cloud.google.com/sdk/gcloud/reference/run/services/update-traffic#--to-latest
+        # Redirect traffic to latest revision
+        revision_traffic: LATEST=100
     

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,10 @@ credentials.csv
 # But in this document, it say `.firebaserc` should be commit...
 # https://firebase.google.com/docs/cli#source_control_aliases
 .firebaserc
+
+# log, emulator cache data
 emulator-data
+pubsub-emulator
 firestore-debug.log
 ui-debug.log
 

--- a/Dockerfile.pubsub.emulator
+++ b/Dockerfile.pubsub.emulator
@@ -1,0 +1,9 @@
+# https://cloud.google.com/sdk/docs/downloads-docker#alpine-based_images
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+
+# install java jre
+# from: https://github.com/seletskiy/firebase-emulator/blob/master/Dockerfile
+RUN apk --update --no-cache add openjdk8-jre
+
+# https://cloud.google.com/pubsub/docs/emulator#using_the_emulator
+RUN gcloud components install pubsub-emulator && gcloud components update

--- a/Dockerfile.python3.pubsub.clients
+++ b/Dockerfile.python3.pubsub.clients
@@ -1,0 +1,12 @@
+FROM python:3.6
+
+WORKDIR /
+# clone wait-for-it script to wait other port are ready and run
+RUN git clone https://github.com/googleapis/python-pubsub.git --depth=1 \
+    && git clone https://github.com/vishnubob/wait-for-it.git --depth=1 \
+    && chmod +x /wait-for-it/wait-for-it.sh
+# https://cloud.google.com/pubsub/docs/emulator#using_the_emulator
+WORKDIR /python-pubsub/samples/snippets
+
+RUN pip install -r requirements.txt
+

--- a/apollo/Dockerfile.test
+++ b/apollo/Dockerfile.test
@@ -1,3 +1,6 @@
+# Dockerfile naming convention
+# https://stackoverflow.com/a/63995752
+# https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f
 FROM node:14-alpine as app
 
 ENV NODE_ENV=production

--- a/apollo/compose.env
+++ b/apollo/compose.env
@@ -17,4 +17,4 @@ ALGOLIA_API_KEY=
 ALGOLIA_INDEX_NAME=
 
 # pub/sub subscription name
-CAMPUS_EVENT_SUPSCRIPTION_NAME=
+CAMPUS_EVENT_SUPSCRIPTION_NAME=projects/test/subscriptions/test-topic-sub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 version: "3.9"
 services:
   emulator:
+    # set up functions emulator locally
+    # especially functions configuration
+    # we need to create `.runtimeconfig.json`
+    # https://firebase.google.com/docs/functions/local-emulator
     build: ./functions
     volumes:
       - .:/node_app/app
@@ -8,7 +12,12 @@ services:
       - ./functions/package-lock.json:/node_app/package-lock.json
       - no-used:/node_app/app/functions/node_modules
       # avoid emulators repeated download
+      # https://firebase.google.com/docs/emulator-suite/install_and_configure#running_containerized_emulator_suite_images
       - emulators:/home/node/.cache/firebase/emulators/
+    # used for pubsub emulator connection
+    environment:
+      - PUBSUB_EMULATOR_HOST=pubsub_emulator:8085
+      - PUBSUB_PROJECT_ID=${PUBSUB_PROJECT_ID:-test}
     ports:
       # need to specify host as 0.0.0.0 so that we can connect to the container
       # fron host
@@ -20,16 +29,56 @@ services:
       - "0.0.0.0:8080:8080"
     stdin_open: true
     tty: true
+  pubsub_emulator:
+    build:
+      context: ./
+      dockerfile: Dockerfile.pubsub.emulator
+    volumes:
+      - ./pubsub-emulator:/pubsub-emulator
+    # https://cloud.google.com/sdk/gcloud/reference/beta/emulators/pubsub/start
+    # default host port is localhost:8085
+    # use --quiet flag to accept default answers for all prompts
+    command: gcloud --quiet beta emulators pubsub start --data-dir=/pubsub-emulator --host-port=pubsub_emulator:8085
+  pubsub_clients_setting:
+    build:
+      context: ./
+      dockerfile: Dockerfile.python3.pubsub.clients
+    # used environment variable to set the compose variable
+    # https://docs.docker.com/compose/environment-variables/
+    environment:
+      - PUBSUB_EMULATOR_HOST=pubsub_emulator:8085
+      - PUBSUB_PROJECT_ID=${PUBSUB_PROJECT_ID:-test}
+    # https://cloud.google.com/pubsub/docs/emulator#using_the_emulator
+    # https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution
+    # a $$ allows you to refer to environment variables that you don’t want processed by Compose.
+    # https://docs.docker.com/engine/reference/builder/#cmd
+    # https://stackoverflow.com/questions/30063907/using-docker-compose-how-to-execute-multiple-commands
+    # use the shell form or execute a shell directly for shell processing
+    command: >
+      bash -c " /wait-for-it/wait-for-it.sh $${PUBSUB_EMULATOR_HOST} --
+      echo \"pubsub emulator ready($${PUBSUB_EMULATOR_HOST}), start pubsub setting...\"
+      && python publisher.py ${PUBSUB_PROJECT_ID:-test} create ${TOPIC_ID:-test-topic}
+      && python subscriber.py ${PUBSUB_PROJECT_ID:-test} create ${TOPIC_ID:-test-topic} ${SUBSCRIPTION_ID:-test-topic-sub}"
+    # https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on
+    # improvement direction: https://docs.docker.com/compose/startup-order/
+    # However, the python pubsub client would wait for port to run and 
+    #   set the pubsub topic and subscription
+    depends_on:
+      - pubsub_emulator
   apollo:
     build: 
       context: ./apollo
-      dockerfile: Dockerfile-testing
+      dockerfile: Dockerfile.test
     volumes: 
       - ./apollo:/node_app/app
       - ./apollo/package.json:/node_app/package.json
       - ./apollo/package-lock.json:/node_app/package-lock.json
       - no-used:/node_app/app/apollo/node_modules
     env_file: ./apollo/compose.env
+    # used for pubsub emulator connection
+    environment:
+      - PUBSUB_EMULATOR_HOST=pubsub_emulator:8085
+      - PUBSUB_PROJECT_ID=${PUBSUB_PROJECT_ID:-test}
     ports:
       - "8333:8080"
 volumes:

--- a/functions/.runtimeconfig.json
+++ b/functions/.runtimeconfig.json
@@ -1,0 +1,5 @@
+{
+  "campus": {
+    "event_topic_name": "projects/test/topics/test-topic"
+  }
+}

--- a/functions/Dockerfile
+++ b/functions/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_ENV=production
 
 # install java jre
 # from: https://github.com/seletskiy/firebase-emulator/blob/master/Dockerfile
-RUN apk --no-cache add openjdk8-jre
+RUN apk --update --no-cache add openjdk8-jre
 
 RUN npm install -g firebase-tools
 

--- a/functions/functionTriggers/deleteTagTrigger.js
+++ b/functions/functionTriggers/deleteTagTrigger.js
@@ -36,11 +36,14 @@ async function deleteTagTrigger(admin, snap) {
       JSON.stringify({
         changeType: "deleted",
         tagContent: {
+          ...snap.data(), // first destruct original objects
+          // * and then replace existed keys
+          // * don't reverse the order!!!(don't assign replaced values first and
+          //   then destruct)
           id: tagId,
           createTime: createTime.toDate().toISOString(),
           lastUpdateTime: lastUpdateTime.toDate().toISOString(),
           coordinates: { latitude, longitude },
-          ...snap.data(),
         },
       })
     );


### PR DESCRIPTION
* Add pubsub emulator server container in the docker-compose.
* Add pubsub python client for setting topic and subscriptions.
* Rename `Dockerfile` to fit official naming convention.
* **Fix bugs of delete events resolve errors.**
* Add new fields in the github actions script to redirect traffic to
  the latest cloud run revision.
* gitignore the `pubsub-emulator`.