### PR TITLE
fix: :bug: Modify docker compose build order

### DIFF
--- a/Dockerfile.pubsub.emulator
+++ b/Dockerfile.pubsub.emulator
@@ -1,9 +1,0 @@
-# https://cloud.google.com/sdk/docs/downloads-docker#alpine-based_images
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
-
-# install java jre
-# from: https://github.com/seletskiy/firebase-emulator/blob/master/Dockerfile
-RUN apk --update --no-cache add openjdk11-jre
-
-# https://cloud.google.com/pubsub/docs/emulator#using_the_emulator
-RUN gcloud components install pubsub-emulator && gcloud components update

--- a/apollo/.eslintrc.json
+++ b/apollo/.eslintrc.json
@@ -11,7 +11,10 @@
   },
   "rules": {
     // https://github.com/prettier/eslint-plugin-prettier#installation
-    "prettier/prettier": "warn",
+    // "prettier/prettier": "warn",
+    "prettier/prettier": ["error",{
+      "endOfLine": "auto"}
+    ],
     "no-console": "off",
     "no-unused-vars": [
       "error",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,18 @@ services:
     tty: true
   pubsub_emulator:
     build:
-      context: ./
-      dockerfile: Dockerfile.pubsub.emulator
+      # https://github.com/GoogleCloudPlatform/cloud-sdk-docker
+      # https://docs.docker.com/engine/reference/commandline/build/#git-repositories
+      # https://docs.docker.com/build/building/context/#url-context
+      # {branch}/{dir}
+      # WARNING: currently could not use remote git source
+      # related to buildkit
+      # https://github.com/docker/compose-cli/issues/1958
+      # context: https://github.com/GoogleCloudPlatform/cloud-sdk-docker.git#master:debian_slim
+      # WORKAROUND: manually clone repo to local from https://github.com/GoogleCloudPlatform/cloud-sdk-docker
+      context: ./cloud-sdk-docker/debian_slim
+      args:
+        - INSTALL_COMPONENTS=google-cloud-cli-app-engine-java google-cloud-cli-pubsub-emulator openjdk-17-jre
     volumes:
       - ./pubsub-emulator:/pubsub-emulator
     # https://cloud.google.com/sdk/gcloud/reference/beta/emulators/pubsub/start


### PR DESCRIPTION
give the args of needed gcp emulator components in docker-compose.yml, to make sure it will be installed before prebuild